### PR TITLE
fixed configmap labels indention + Chart version bump

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.1
+version: 0.1.2
 appVersion: '0.1.7'

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: {{ include "manifest.fullname" . }}-env
-    labels:
-        {{- include "manifest.labels" . | nindent 4 }}
+  name: {{ include "manifest.fullname" . }}-env
+  labels:
+    {{- include "manifest.labels" . | nindent 4 }}
 data:
-    CONJUR_API_URL: {{ .Values.conjurApiUrl | quote  | default "https://conjur-oss"}}
-    CONJUR_AUTHN: {{ .Values.conjurAuthn | quote  | default "authn"}}
-    COOKIE_HTTP_SECURE: {{ .Values.httpSecureCookie | quote | default "false" }}
-    PORT: {{ .Values.service.port | quote | default "8080" }}
-    NODE_EXTRA_CA_CERTS: /etc/ssl/certs/conjur-certificate.pem
+  CONJUR_API_URL: {{ .Values.conjurApiUrl | quote  | default "https://conjur-oss"}}
+  CONJUR_AUTHN: {{ .Values.conjurAuthn | quote  | default "authn"}}
+  COOKIE_HTTP_SECURE: {{ .Values.httpSecureCookie | quote | default "false" }}
+  PORT: {{ .Values.service.port | quote | default "8080" }}
+  NODE_EXTRA_CA_CERTS: /etc/ssl/certs/conjur-certificate.pem


### PR DESCRIPTION
With the current version of configmap template I get this when installing the chart:

W0319 13:42:11.916981 2446019 warnings.go:70] unknown field "metadata.app.kubernetes.io/instance"
W0319 13:42:11.917025 2446019 warnings.go:70] unknown field "metadata.app.kubernetes.io/managed-by"
W0319 13:42:11.917038 2446019 warnings.go:70] unknown field "metadata.app.kubernetes.io/name"
W0319 13:42:11.917050 2446019 warnings.go:70] unknown field "metadata.app.kubernetes.io/version"
W0319 13:42:11.917063 2446019 warnings.go:70] unknown field "metadata.helm.sh/chart"